### PR TITLE
bower.json: Trimmed trailing commas

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "bootstrap": "2.3.2",
-    "fastclick": "lattest"
+    "fastclick": "master"
   },
   "devDependencies": {
     "bootstrap": "2.3.2"

--- a/bower.json
+++ b/bower.json
@@ -6,13 +6,13 @@
     "git.php",
     "codekit-config.json",
     "demo/less",
-    "**/*.txt",
+    "**/*.txt"
   ],
   "dependencies": {
     "bootstrap": "2.3.2",
-    "fastclick": "lattest",
+    "fastclick": "lattest"
   },
   "devDependencies": {
-    "bootstrap": "2.3.2",
+    "bootstrap": "2.3.2"
   }
 }


### PR DESCRIPTION
Removed trailing commas from bower.json.
bower install fails with "Unexpected token ]", and I believe this is the reason.

Also, changed "lattest" to "master" in fastclick dependency.